### PR TITLE
Changed naming convention of first file in multifile generation

### DIFF
--- a/OpenbuildsFusion360PostGrbl.cps
+++ b/OpenbuildsFusion360PostGrbl.cps
@@ -41,8 +41,9 @@ Changelog
 12 Nov 2021 - V1.0.28 : Added property group names, fixed default router selection, now uses permittedCommentChars  (sharmstr)
 24 Nov 2021 - V1.0.28 : Improved coolant selection, tweaked property groups, tweaked G53 generation, links for help in comments.
 21 Feb 2022 - V1.0.29 : Fix sideeffects of drill operation having rapids even when in noRapid mode by always resetting haveRapid in onSection
+10 May 2022 - V1.0.30 : Change naming convention for first file in multifile output
 */
-obversion = 'V1.0.29';
+obversion = 'V1.0.30';
 description = "OpenBuilds CNC : GRBL/BlackBox";  // cannot have brackets in comments
 longDescription = description + " : Post" + obversion; // adds description to post library diaglog box
 vendor = "OpenBuilds";
@@ -508,14 +509,14 @@ function writeHeader(secID)
       }
    writeln("");
 
-   if (properties.generateMultiple)
+   if (properties.generateMultiple && filesToGenerate > 1)
       {
       writeComment(numberOfSections + " Operation" + ((numberOfSections == 1) ? "" : "s") + " in " + filesToGenerate + " files.");
       writeComment("File List:");
-      writeComment("  " +  FileSystem.getFilename(getOutputPath()));
-      for (var i = 0; i < filesToGenerate - 1; ++i)
+      //writeComment("  " +  FileSystem.getFilename(getOutputPath()));
+      for (var i = 0; i < filesToGenerate; ++i)
          {
-         filenamePath = FileSystem.replaceExtension(getOutputPath(), fileIndexFormat.format(i + 2) + "of" + filesToGenerate + "." + extension);
+         filenamePath = FileSystem.replaceExtension(getOutputPath(), fileIndexFormat.format(i + 1) + "of" + filesToGenerate + "." + extension);
          filename = FileSystem.getFilename(filenamePath);
          writeComment("  " + filename);
          }
@@ -1274,11 +1275,14 @@ function onClose()
 
 function onTerminate()
    {
-   //The idea here was to rename the first file to <filename>.001ofX.nc so that when multiple files were generated, they all had the same naming conventionl
-   //While this does work, the auto load into Brackets loads a log file instead of the gcode file.
-
-   //var fileIndexFormat = createFormat({width:3, zeropad: true, decimals:0});
-   //FileSystem.moveFile(getOutputPath(), FileSystem.replaceExtension(getOutputPath(), fileIndexFormat.format(1) + "of" + filesToGenerate + ".nc"));
+   // If we are generating multiple files, then rename first file to add # of #
+   // If you dont want to show the log file, then untick "open in Open file in NC editor"
+   if (filesToGenerate > 1) {
+     var fileIndexFormat = createFormat({ width: 2, zeropad: true, decimals: 0 });
+     var newOutput = FileSystem.replaceExtension(getOutputPath(), fileIndexFormat.format(1) + 'of' + filesToGenerate + '.' + extension);
+     FileSystem.moveFile(getOutputPath(), newOutput);
+     executeNoWait(newOutput, '', false, '');
+    }
    }
 
 function onCommand(command)

--- a/OpenbuildsFusion360PostGrbl.cps
+++ b/OpenbuildsFusion360PostGrbl.cps
@@ -41,7 +41,6 @@ Changelog
 12 Nov 2021 - V1.0.28 : Added property group names, fixed default router selection, now uses permittedCommentChars  (sharmstr)
 24 Nov 2021 - V1.0.28 : Improved coolant selection, tweaked property groups, tweaked G53 generation, links for help in comments.
 21 Feb 2022 - V1.0.29 : Fix sideeffects of drill operation having rapids even when in noRapid mode by always resetting haveRapid in onSection
-
 */
 obversion = 'V1.0.29';
 description = "OpenBuilds CNC : GRBL/BlackBox";  // cannot have brackets in comments

--- a/OpenbuildsFusion360PostGrbl.cps
+++ b/OpenbuildsFusion360PostGrbl.cps
@@ -41,6 +41,7 @@ Changelog
 12 Nov 2021 - V1.0.28 : Added property group names, fixed default router selection, now uses permittedCommentChars  (sharmstr)
 24 Nov 2021 - V1.0.28 : Improved coolant selection, tweaked property groups, tweaked G53 generation, links for help in comments.
 21 Feb 2022 - V1.0.29 : Fix sideeffects of drill operation having rapids even when in noRapid mode by always resetting haveRapid in onSection
+
 */
 obversion = 'V1.0.29';
 description = "OpenBuilds CNC : GRBL/BlackBox";  // cannot have brackets in comments


### PR DESCRIPTION
Tried to do this years ago but "open in nc editor" would open a log file instead of the first gcode file.  Figured out how to get it to open the first file.  Now, if you untick "open in nc editor" the first file will open in the editor (makes no sense I know, but it works).  If you tick "open in nc editor" it will open the log file, but will also open the first file.