### PR TITLE
Trying to solve file rename error

### DIFF
--- a/OpenbuildsFusion360PostGrbl.cps
+++ b/OpenbuildsFusion360PostGrbl.cps
@@ -41,8 +41,9 @@ Changelog
 12 Nov 2021 - V1.0.28 : Added property group names, fixed default router selection, now uses permittedCommentChars  (sharmstr)
 24 Nov 2021 - V1.0.28 : Improved coolant selection, tweaked property groups, tweaked G53 generation, links for help in comments.
 21 Feb 2022 - V1.0.29 : Fix sideeffects of drill operation having rapids even when in noRapid mode by always resetting haveRapid in onSection
+10 May 2022 - V1.0.30 : Change naming convention for first file in multifile output
 */
-obversion = 'V1.0.29';
+obversion = 'V1.0.30';
 description = "OpenBuilds CNC : GRBL/BlackBox";  // cannot have brackets in comments
 longDescription = description + " : Post" + obversion; // adds description to post library diaglog box
 vendor = "OpenBuilds";
@@ -508,14 +509,14 @@ function writeHeader(secID)
       }
    writeln("");
 
-   if (properties.generateMultiple)
+   if (properties.generateMultiple && filesToGenerate > 1)
       {
       writeComment(numberOfSections + " Operation" + ((numberOfSections == 1) ? "" : "s") + " in " + filesToGenerate + " files.");
       writeComment("File List:");
-      writeComment("  " +  FileSystem.getFilename(getOutputPath()));
-      for (var i = 0; i < filesToGenerate - 1; ++i)
+      //writeComment("  " +  FileSystem.getFilename(getOutputPath()));
+      for (var i = 0; i < filesToGenerate; ++i)
          {
-         filenamePath = FileSystem.replaceExtension(getOutputPath(), fileIndexFormat.format(i + 2) + "of" + filesToGenerate + "." + extension);
+         filenamePath = FileSystem.replaceExtension(getOutputPath(), fileIndexFormat.format(i + 1) + "of" + filesToGenerate + "." + extension);
          filename = FileSystem.getFilename(filenamePath);
          writeComment("  " + filename);
          }
@@ -1274,11 +1275,14 @@ function onClose()
 
 function onTerminate()
    {
-   //The idea here was to rename the first file to <filename>.001ofX.nc so that when multiple files were generated, they all had the same naming conventionl
-   //While this does work, the auto load into Brackets loads a log file instead of the gcode file.
-
-   //var fileIndexFormat = createFormat({width:3, zeropad: true, decimals:0});
-   //FileSystem.moveFile(getOutputPath(), FileSystem.replaceExtension(getOutputPath(), fileIndexFormat.format(1) + "of" + filesToGenerate + ".nc"));
+   // If we are generating multiple files, then rename first file to add # of #
+   // If you dont want to show the log file, then untick "open in Open file in NC editor"
+   if (filesToGenerate > 1) {
+     var fileIndexFormat = createFormat({ width: 2, zeropad: true, decimals: 0 });
+     var newOutput = FileSystem.replaceExtension(getOutputPath(), fileIndexFormat.format(1) + 'of' + filesToGenerate + '.' + extension);
+     FileSystem.moveFile(getOutputPath(), newOutput);
+     executeNoWait(newOutput, '', false, '');
+    }
    }
 
 function onCommand(command)

--- a/OpenbuildsFusion360PostGrbl.cps
+++ b/OpenbuildsFusion360PostGrbl.cps
@@ -41,7 +41,6 @@ Changelog
 12 Nov 2021 - V1.0.28 : Added property group names, fixed default router selection, now uses permittedCommentChars  (sharmstr)
 24 Nov 2021 - V1.0.28 : Improved coolant selection, tweaked property groups, tweaked G53 generation, links for help in comments.
 21 Feb 2022 - V1.0.29 : Fix sideeffects of drill operation having rapids even when in noRapid mode by always resetting haveRapid in onSection
-
 */
 obversion = 'V1.0.29';
 description = "OpenBuilds CNC : GRBL/BlackBox";  // cannot have brackets in comments

--- a/OpenbuildsFusion360PostGrbl.cps
+++ b/OpenbuildsFusion360PostGrbl.cps
@@ -41,6 +41,7 @@ Changelog
 12 Nov 2021 - V1.0.28 : Added property group names, fixed default router selection, now uses permittedCommentChars  (sharmstr)
 24 Nov 2021 - V1.0.28 : Improved coolant selection, tweaked property groups, tweaked G53 generation, links for help in comments.
 21 Feb 2022 - V1.0.29 : Fix sideeffects of drill operation having rapids even when in noRapid mode by always resetting haveRapid in onSection
+
 */
 obversion = 'V1.0.29';
 description = "OpenBuilds CNC : GRBL/BlackBox";  // cannot have brackets in comments

--- a/OpenbuildsFusion360PostGrbl.cps
+++ b/OpenbuildsFusion360PostGrbl.cps
@@ -41,7 +41,7 @@ Changelog
 12 Nov 2021 - V1.0.28 : Added property group names, fixed default router selection, now uses permittedCommentChars  (sharmstr)
 24 Nov 2021 - V1.0.28 : Improved coolant selection, tweaked property groups, tweaked G53 generation, links for help in comments.
 21 Feb 2022 - V1.0.29 : Fix sideeffects of drill operation having rapids even when in noRapid mode by always resetting haveRapid in onSection
-10 May 2022 - V1.0.30 : Change naming convention for first file in multifile output
+15 May 2022 - V1.0.30 : Change naming convention for first file in multifile output
 */
 obversion = 'V1.0.30';
 description = "OpenBuilds CNC : GRBL/BlackBox";  // cannot have brackets in comments
@@ -1275,13 +1275,22 @@ function onClose()
 
 function onTerminate()
    {
-   // If we are generating multiple files, then rename first file to add # of #
-   // If you dont want to show the log file, then untick "open in Open file in NC editor"
+   // If we are generating multiple files, copy first file to add # of #
+   // Then remove first file and recreate with file list
    if (filesToGenerate > 1) {
-     var fileIndexFormat = createFormat({ width: 2, zeropad: true, decimals: 0 });
-     var newOutput = FileSystem.replaceExtension(getOutputPath(), fileIndexFormat.format(1) + 'of' + filesToGenerate + '.' + extension);
-     FileSystem.moveFile(getOutputPath(), newOutput);
-     executeNoWait(newOutput, '', false, '');
+    var outputPath = getOutputPath();
+    var outputFolder = FileSystem.getFolderPath(getOutputPath());
+    var programFilename = FileSystem.getFilename(outputPath);
+    var newOutput = FileSystem.replaceExtension(getOutputPath(), fileIndexFormat.format(1) + 'of' + filesToGenerate + '.' + extension);
+    executeNoWait(newOutput, '', false, '');
+    FileSystem.remove(outputPath);
+
+    var file = new TextFile(outputFolder + "\\" + programFilename, true, "ansi");
+    file.writeln("The following gcode files were created: ");
+    for (var i = 0; i < filesToGenerate; ++i) {
+      file.writeln(programName + '.' + fileIndexFormat.format(i + 1) + 'of' + filesToGenerate + '.' + extension);
+    }
+    file.close();     
     }
    }
 


### PR DESCRIPTION
There's no clean way to rename the program file.  However, we can:

- Copy first file to add the sequence number
- Then delete first file
- Then recreate first file with a file list as its contents. 

Example:
The following gcode files were created: 
1001.01of5.gcode
1001.02of5.gcode
1001.03of5.gcode
1001.04of5.gcode
1001.05of5.gcode

Fusion wont throw an error because the original/new file can be found.  Both the original file and the copied file will open in the nc editor.