### PR TITLE
as of Fusion 2603.1.15, rapid move is not working

### DIFF
--- a/OpenbuildsFusion360PostGrbl.cps
+++ b/OpenbuildsFusion360PostGrbl.cps
@@ -1443,9 +1443,10 @@ function onLinear(_x, _y, _z, feed)
       if (x || y || z)
          {
          linmove = 1;          // have to have a default!
-         if (!OB.haveRapid && z)  // if z is changing
+         if (!OB.haveRapid)
             {
-            if (_z < retractHeight) // compare it to retractHeight, below that is G1, >= is G0
+            var currentZ = zOutput.getCurrent()
+            if (currentZ < retractHeight) // compare it to retractHeight, below that is G1, >= is G0
                linmove = 1;
             else
                linmove = 0;


### PR DESCRIPTION
the XY and Z sent separately as result the rapid move is detected only for Z move.
Getting the current Z value for every line move to check against retractHeight allows to set correct move type for rapid move.